### PR TITLE
Add new dataset: ActTrace Ego-Home

### DIFF
--- a/datasets/ActTrace_Ego-Home/README.md
+++ b/datasets/ActTrace_Ego-Home/README.md
@@ -1,0 +1,35 @@
+# ActTrace Ego-Home
+
+
+## Introduction
+
+ActTrace Ego-Home focuses on measurement quality over volume: every stream is measured or independently verified, never merely estimated. v0.2 ships 13 episodes (18.0 minutes, 11 household tasks) with 9 synchronized columns: 1080p60 ultra-wide RGB video, metric LiDAR depth (16-bit millimeters, per-pixel confidence), 100 Hz head IMU, dual-hand 2D keypoints with per-point confidence, metric 3D hand trajectories lifted through in-app-calibrated dual-camera extrinsics plus LiDAR depth, 6-DoF head trajectories (TUM format, 30 Hz, up-to-scale), per-frame camera metadata, a cross-stream clock anchor, and dual-register language annotations (verbatim human narration plus machine-generated imperative instruction, provenance disclosed field-by-field).
+
+Every released head trajectory must survive a cross-examination against the gyroscope (angular-rate correlation, shipping bar r >= 0.97, alignment residual <= 0.03 s); episodes that fail are re-recorded or not released, and the dataset card documents the capture-protocol fix (a slow 5-second look-around at episode start and end) that rescued three initially-failing episodes. Per-episode QC health reports and a LeRobot v2.1 converter are included. Free for research (CC BY-NC 4.0); commercial licensing and custom collection are available.
+
+
+## Homepage
+
+[Visit the dataset homepage](https://huggingface.co/datasets/ActTrace/acttrace-ego-home)
+
+
+## Task Description
+
+A human demonstrator wearing a head-mounted iPhone performs real household manipulation tasks in real homes: washing cups and dishes, folding laundry and T-shirts, cutting fruit, beating eggs, boiling and pouring water, unpacking parcels, changing trash bags, and clearing the table after a meal. Every episode ships with verbatim human narration plus a machine-generated imperative instruction (provenance disclosed) and human-confirmed action segments with handedness.
+
+
+## Dataset Details
+
+- **license**: CC BY-NC 4.0
+- **episodes**: 13
+- **file_size**: 4.2 GB
+- **scene_type**: Real Home
+- **data_collect_method**: Human demonstration (head-mounted iPhone, ultra-wide RGB + LiDAR)
+- **robot**: null (human egocentric demonstration, no robot embodiment)
+- **rgb_cams**: 1
+- **depth_cams**: 1
+- **wrist_cams**: 0
+- **has_camera_calibration**: true
+- **has_proprioception**: false
+- **has_suboptimal**: false
+- **language_annotations**: Natural (verbatim human narration + machine-generated imperative instruction, provenance disclosed)

--- a/datasets/ActTrace_Ego-Home/info.yaml
+++ b/datasets/ActTrace_Ego-Home/info.yaml
@@ -1,0 +1,25 @@
+## Required fields
+name: "ActTrace Ego-Home"
+license: "CC BY-NC 4.0"
+url: "https://huggingface.co/datasets/ActTrace/acttrace-ego-home"
+short_introduction: "Egocentric household-manipulation dataset recorded with a head-mounted iPhone in real Chinese homes: metric LiDAR depth, 100 Hz IMU, metric 3D hand trajectories lifted through calibrated extrinsics, and 6-DoF head trajectories cross-validated against the IMU (shipping bar r >= 0.97; v0.2 ships 13/13 episodes at r = 0.971-0.995; failing trajectories are not released)."
+task_description: "A human demonstrator wearing a head-mounted iPhone performs real household manipulation tasks in real homes: washing cups and dishes, folding laundry and T-shirts, cutting fruit, beating eggs, boiling and pouring water, unpacking parcels, changing trash bags, and clearing the table after a meal. Every episode ships with verbatim human narration plus a machine-generated imperative instruction (provenance disclosed) and human-confirmed action segments with handedness."
+
+## Optional fields
+data_collect_method: "Human demonstration (head-mounted iPhone, ultra-wide RGB + LiDAR)"
+depth_cams: 1
+episodes: 13
+file_size: 4.2
+has_camera_calibration: true
+has_proprioception: false
+has_suboptimal: false
+language_annotations: "Natural (verbatim human narration + machine-generated imperative instruction, provenance disclosed)"
+rgb_cams: 1
+robot: "null"
+robot_morphology: "Human egocentric (no robot embodiment)"
+scene_type: "Real Home"
+wrist_cams: 0
+
+## Custom fields
+custom_fields:
+  introduction: "ActTrace Ego-Home focuses on measurement quality over volume: every stream is measured or independently verified, never merely estimated. v0.2 ships 13 episodes (18.0 minutes, 11 household tasks) with 9 synchronized columns: 1080p60 ultra-wide RGB video, metric LiDAR depth (16-bit millimeters, per-pixel confidence), 100 Hz head IMU, dual-hand 2D keypoints with per-point confidence, metric 3D hand trajectories lifted through in-app-calibrated dual-camera extrinsics plus LiDAR depth, 6-DoF head trajectories (TUM format, 30 Hz, up-to-scale), per-frame camera metadata, a cross-stream clock anchor, and dual-register language annotations. Every released head trajectory must survive a cross-examination against the gyroscope (angular-rate correlation, shipping bar r >= 0.97, alignment residual <= 0.03 s); episodes that fail are re-recorded or not released, and the dataset card documents the capture-protocol fix (a slow 5-second look-around at episode start and end) that rescued three initially-failing episodes. Per-episode QC health reports and a LeRobot v2.1 converter are included. Free for research (CC BY-NC 4.0); commercial licensing and custom collection available."


### PR DESCRIPTION
Adds ActTrace Ego-Home v0.2 under datasets/ActTrace_Ego-Home/ (info.yaml + README.md), following the example dataset template. It is an egocentric household-manipulation dataset focused on measurement quality: 13 episodes recorded with a head-mounted iPhone in real homes, with metric LiDAR depth, 100 Hz IMU, metric 3D hand trajectories lifted through calibrated extrinsics, and 6-DoF head trajectories cross-validated against the IMU (shipping bar r >= 0.97; this release 13/13 pass at 0.971-0.995). Language annotations ship in two registers with machine/human provenance disclosed; LeRobot converter included. Note: I could not run scripts/check_dataset.py and render_dataset_readme.py locally, so README.md was written by hand following the template structure - happy to adjust if the CI render differs.